### PR TITLE
Use C-h C-j C-k C-l to move seamlessly between tmux panes and vim splits

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -60,3 +60,15 @@ set -g status-right ''
 set -g status-left '⿻#S'
 set -g window-status-format "#[fg=white] #I #W "
 set -g window-status-current-format "#[fg=colour234,bg=colour109] #I #W "
+
+# Smart pane switching with awareness of vim splits
+# ctrl-h: left pane, ctrl-j: down pane, ctrl-k: up pane, ctrl-l: right pane,
+# ctrl-\: previous pane
+# See: https://github.com/christoomey/vim-tmux-navigator
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
+bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
+bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
+bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
+bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"

--- a/vimrc
+++ b/vimrc
@@ -52,6 +52,8 @@ Plugin 'SirVer/ultisnips'
 " see https://github.com/easymotion/vim-easymotion
 Plugin 'easymotion/vim-easymotion'
 Plugin 'leafgarland/typescript-vim'
+" see https://github.com/christoomey/vim-tmux-navigator
+Plugin 'christoomey/vim-tmux-navigator'
 
 " Hit <tab> to expand a snippet, and ctrl-j and -k to move forward and
 " backward between the tab stops in the snippet


### PR DESCRIPTION
See: [https://github.com/christoomey/vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator)

Note: This didn't work for me in Tmux  v2.0 but did in v2.2.
