### PR TITLE
fix copy-paste in tmux 2.4

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -5,20 +5,36 @@ set -g mouse on
 bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
 bind -n WheelDownPane select-pane -t= \; send-keys -M
 bind -n C-WheelUpPane select-pane -t= \; copy-mode -e \; send-keys -M
-bind -t vi-copy    C-WheelUpPane   halfpage-up
-bind -t vi-copy    C-WheelDownPane halfpage-down
-bind -t emacs-copy C-WheelUpPane   halfpage-up
-bind -t emacs-copy C-WheelDownPane halfpage-down
+
+run-shell "tmux setenv -g TMUX_VERSION $(tmux -V | cut -c 6-)"
+
+# tmux 2.4 changed how these bindings work
+if-shell -b '[ "$(echo "$TMUX_VERSION < 2.4" | bc)" = 1 ]' \
+  "bind -t vi-copy    C-WheelUpPane   halfpage-up; \
+    bind -t vi-copy    C-WheelDownPane halfpage-down; \
+    bind -t emacs-copy C-WheelUpPane   halfpage-up; \
+    bind -t emacs-copy C-WheelDownPane halfpage-down"
+
+if-shell -b '[ "$(echo "$TMUX_VERSION >= 2.4" | bc)" = 1 ]' \
+  "bind -T copy-mode-vi C-WheelUpPane send -X halfpage-up; \
+    bind -T copy-mode-vi C-WheelDownPane send -X halfpage-down"
+
 
 # from http://robots.thoughtbot.com/tmux-copy-paste-on-os-x-a-better-future
 # Setup 'v' to begin selection as in Vim
-bind-key -t vi-copy v begin-selection
-bind-key -t vi-copy y copy-pipe "reattach-to-user-namespace pbcopy"
-# Update default binding of `Enter` to also use copy-pipe
-unbind -t vi-copy Enter
-bind-key -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"
+if-shell -b '[ "$(echo "$TMUX_VERSION < 2.4" | bc)" = 1 ]' \
+  "bind-key -t vi-copy v begin-selection; \
+    bind-key -t vi-copy y copy-pipe 'reattach-to-user-namespace pbcopy'; \
+    unbind -t vi-copy Enter; \
+    bind-key -t vi-copy Enter copy-pipe 'reattach-to-user-namespace pbcopy'"
 
-# vim keys
+if-shell -b '[ "$(echo "$TMUX_VERSION >= 2.4" | bc)" = 1 ]' \
+  "bind-key -T copy-mode-vi 'v' send -X begin-selection; \
+    bind-key -T copy-mode-vi 'y' send-keys -X copy-pipe-and-cancel 'reattach-to-user-namespace pbcopy'; \
+    unbind -T copy-mode-vi Enter; \
+    bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel 'reattach-to-user-namespace pbcopy'"
+
+# vim keys, see: https://sanctum.geek.nz/arabesque/vi-mode-in-tmux/
 setw -g mode-keys vi
 bind h select-pane -L
 bind j select-pane -D


### PR DESCRIPTION
key binding commands changed in tmux 2.4, this fixes copy-paste in copy-mode-vi for tmux 2.4